### PR TITLE
VelocityのテンプレートでListを使えるように修正(ユニットテスト修正)

### DIFF
--- a/src/test/java/nablarch/integration/mail/velocity/VelocityMailProcessorContainerManagedTest.java
+++ b/src/test/java/nablarch/integration/mail/velocity/VelocityMailProcessorContainerManagedTest.java
@@ -46,7 +46,7 @@ public class VelocityMailProcessorContainerManagedTest {
                 Collections.unmodifiableMap(variables));
 
         assertThat(result.getSubject(), is("あああ0"));
-        assertThat(result.getMailBody(), is("いいい\r\nえええ1\r\nえええ2\r\nえええ3\r\n"));
+        assertThat(result.getMailBody(), is("いいい\nえええ1\nえええ2\nえええ3\n"));
     }
 
     public static class VelocityEngineFactory implements ComponentFactory<VelocityEngine> {


### PR DESCRIPTION
#3 のユニットテスト修正。  
テンプレートに「\r」が含まれていないのに、テストの期待値に「\r」が含まれていたのでテストに失敗していた。